### PR TITLE
RFC conformity and label compression for cat-dns

### DIFF
--- a/cat-dns.js
+++ b/cat-dns.js
@@ -80,7 +80,7 @@ function createCatAnswer(query) {
   cat.transmogrifyIntoAnswer();
 
   // Resolve imgur correctly or there's no cats.
-  var url = getBinaryStringAsBuffer(cat.answer.qname).toString();
+  var url = getBinaryStringAsBuffer(cat.question.qname).toString();
   var resolvedIp = (url.indexOf("imgur") != -1) ? imgurIP : catServerIP;
   cat.answer.rdata = getBinaryStringFromIp(resolvedIp);
   return cat;


### PR DESCRIPTION
This change addresses https://github.com/notwaldorf/cat-dns/issues/4, https://github.com/notwaldorf/cat-dns/issues/5 and https://github.com/notwaldorf/cat-dns/issues/6 . 

With these changes, cat-dns now includes the original question, works with EDNS0 options (try dig +bufsize=4096 www.example.com @localhost) and makes the answer name a compressed pointer to the query name. 
