### PR TITLE
Creates option to bind server to custom host

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,24 @@ npm install
 ```
 
 To run, start the server as a privileged process. This is because to be a DNS server, you need to be a UDP server on port 53. This is a small numbered port, which means it needs superpowers (however these are dumped once started). This is how your run it: 
+
 ```
 sudo node cat-dns.js
 ```
 
 By default, cat-dns will run attached to the `localhost` address. To bind this to a specific IP address on your host run:
+
 ```
-sudo node cat-dns.js --host 192.168.1.10
+sudo node cat-dns.js --address 192.168.1.10
 ```
 
 Be careful running this on network addresses other than localhost. Other
 machines with access to the host you bind to can make DNS queries. For
 instance, binding to `0.0.0.0` and exposing your machine to the internet
-will allow anyone with access to the internet make DNS queries to your
+will allow anyone with access to the internet to make DNS queries to your
 machine.
 
-You also need to somehow set your DNS server to be localhost. On a Mac, I do this by creating a new (wi-fi) interface (called Cats), in my Network preferences, and settings its DNS server to `127.0.0.1`. You could do this on your normal interface, but as a warning, while you're playing with this, pretty much nothing on your computer that requires the internet works. Except for your browser. And then that's mostly cats. So being able to deactivate it easily is kind of key (I know. You might think 'Why would I ever want to deactivate cats?', but trust me on this one). I also recommend killing all the things that need to call the mothership (google hangouts, twitter feeds, dropbox, iMessage), because they will not like your sassy cat answers, and will slow everything down.
+To run on your local system, you need to somehow set your DNS server to be localhost. On a Mac, I do this by creating a new (wi-fi) interface (called Cats), in my Network preferences, and settings its DNS server to `127.0.0.1`. You could do this on your normal interface, but as a warning, while you're playing with this, pretty much nothing on your computer that requires the internet works. Except for your browser. And then that's mostly cats. So being able to deactivate it easily is kind of key (I know. You might think 'Why would I ever want to deactivate cats?', but trust me on this one). I also recommend killing all the things that need to call the mothership (google hangouts, twitter feeds, dropbox, iMessage), because they will not like your sassy cat answers, and will slow everything down.
 
 ### You are ready
 Go in your browser to `www.google.com` and wait a bit. You should see a cat. Go to a different website. Another cat. Congratulations. Your internet is now all cats.

--- a/README.md
+++ b/README.md
@@ -15,10 +15,16 @@ To run, start the server as a privileged process. This is because to be a DNS se
 sudo node cat-dns.js
 ```
 
-To bind this to a specific IP address on your host run:
+By default, cat-dns will run attached to the `localhost` address. To bind this to a specific IP address on your host run:
 ```
 sudo node cat-dns.js --host 192.168.1.10
 ```
+
+Be careful running this on network addresses other than localhost. Other
+machines with access to the host you bind to can make DNS queries. For
+instance, binding to `0.0.0.0` and exposing your machine to the internet
+will allow anyone with access to the internet make DNS queries to your
+machine.
 
 You also need to somehow set your DNS server to be localhost. On a Mac, I do this by creating a new (wi-fi) interface (called Cats), in my Network preferences, and settings its DNS server to `127.0.0.1`. You could do this on your normal interface, but as a warning, while you're playing with this, pretty much nothing on your computer that requires the internet works. Except for your browser. And then that's mostly cats. So being able to deactivate it easily is kind of key (I know. You might think 'Why would I ever want to deactivate cats?', but trust me on this one). I also recommend killing all the things that need to call the mothership (google hangouts, twitter feeds, dropbox, iMessage), because they will not like your sassy cat answers, and will slow everything down.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ To run, start the server as a privileged process. This is because to be a DNS se
 ```
 sudo node cat-dns.js
 ```
+
+To bind this to a specific IP address on your host run:
+```
+sudo node cat-dns.js --host 192.168.1.10
+```
+
 You also need to somehow set your DNS server to be localhost. On a Mac, I do this by creating a new (wi-fi) interface (called Cats), in my Network preferences, and settings its DNS server to `127.0.0.1`. You could do this on your normal interface, but as a warning, while you're playing with this, pretty much nothing on your computer that requires the internet works. Except for your browser. And then that's mostly cats. So being able to deactivate it easily is kind of key (I know. You might think 'Why would I ever want to deactivate cats?', but trust me on this one). I also recommend killing all the things that need to call the mothership (google hangouts, twitter feeds, dropbox, iMessage), because they will not like your sassy cat answers, and will slow everything down.
 
 ### You are ready

--- a/cat-dns.js
+++ b/cat-dns.js
@@ -5,12 +5,23 @@ var BitArray = require('node-bitarray'),
 
 // This is a magical place of cats. This place keeps changing, so if you're getting a 
 // 502, check what cats.nanobit.org *actually* resolves to, and use that. Sorry!
-var catServerIP = "104.131.51.57"; 
+var catServerIP = "104.131.51.57";
 var imgurIP = "23.23.110.58";
+
+// Argument parser
+var flags = {
+  host : 'localhost'
+};
+
+process.argv.forEach(function (val, index, array) {
+  if(val == '-h' || val == '--host') {
+    flags.host = process.argv[index + 1];
+  }
+});
 
 // DNS Server.
 var dnsServer = dgram.createSocket('udp4');
-dnsServer.bind(53, 'localhost');
+dnsServer.bind(53, flags.host);
 
 dnsServer.on('message', function (msg, rinfo) {
   var start = new Date().getTime();
@@ -19,7 +30,6 @@ dnsServer.on('message', function (msg, rinfo) {
 
   var answer = createCatAnswer(query);
   var answerEnd = new Date().getTime();
-  
   var buffer = answer.toBuffer();
   var bufferEnd = new Date().getTime();
 
@@ -33,7 +43,7 @@ dnsServer.on('message', function (msg, rinfo) {
 });
 
 dnsServer.on("listening", function () {
-  console.log("Cat DNS is live");
+  console.log("Cat DNS is live on host " + flags.host);
   if (process.getuid && process.setuid) {
     console.log("Current uid: " + process.getuid());
     try {

--- a/cat-dns.js
+++ b/cat-dns.js
@@ -14,7 +14,7 @@ var flags = {
 };
 
 process.argv.forEach(function (val, index, array) {
-  if(val == '-h' || val == '--host') {
+  if(val == '-a' || val == '--address') {
     flags.host = process.argv[index + 1];
   }
 });


### PR DESCRIPTION
Was trolling around today for great April Fools' day software. Found it. Thank you @notwaldorf for such a great contribution to basic internet infrastructure.

This PR simply adds a host to bind the DNS server to. 

This is important because I intend to re-route the office's DNS traffic to my host on our NAT.

To test, issue this at the command line:

```js
sudo node cat-dns.js --host 10.10.1.20
```

or

```js
sudo node cat-dns.js -h 10.10.1.20
```